### PR TITLE
Fix networks

### DIFF
--- a/style.css
+++ b/style.css
@@ -187,7 +187,7 @@ h3::before {
     .networks {
         display: flex;
         justify-content: space-between;
-        /* PACO !!!!!!!!!!!!!!!! este space-between no me deja porque arriba (line 77) hay un column gap */
+        width: 100%;
     }
 }
 


### PR DESCRIPTION
El problema es que el `.networks` tiene el tamaño de los hijos, y los hijos son pequeños asi que no "crece". Con un `width: 100%` se arregla:

https://jsfiddle.net/franciscop/7vnoyr5k/2/